### PR TITLE
Upload main road meshes to GPU memory to reduce RAM usage

### DIFF
--- a/Transit.Framework/AssetManager.cs
+++ b/Transit.Framework/AssetManager.cs
@@ -79,8 +79,11 @@ namespace Transit.Framework
                 mesh.LoadOBJ(OBJLoader.LoadOBJ(fileStream));
             }
             mesh.Optimize();
-            mesh.name = Path.GetFileNameWithoutExtension(meshName);
-
+            var name = Path.GetFileNameWithoutExtension(meshName);
+            mesh.name = name;
+            if (!name.Contains("LOD")) { 
+                mesh.UploadMeshData(true);
+            }
             return mesh;
         }
 

--- a/Transit.Framework/Texturing/TextureHelper.cs
+++ b/Transit.Framework/Texturing/TextureHelper.cs
@@ -40,7 +40,8 @@ namespace Transit.Framework.Texturing
                         texture.LoadImage(textureBytes);
                         texture.anisoLevel = 8;
                         texture.filterMode = FilterMode.Bilinear;
-                        texture.Apply();
+                        texture.Compress(true);
+                        texture.Apply(true, true);
                         return texture;
                     }
 
@@ -51,8 +52,8 @@ namespace Transit.Framework.Texturing
                         texture.LoadImage(textureBytes);
                         texture.anisoLevel = 8;
                         texture.filterMode = FilterMode.Bilinear;
+                        texture.Compress(true);
                         texture.Apply();
-                        texture.Compress(false);
                         return texture;
                     }
 


### PR DESCRIPTION
This code uploads mesh to GPU (like in vanilla game) and frees RAM memory used by mesh. LOD meshes should remain in RAM.
